### PR TITLE
Live URL updating and back-button history rewritng to reflect the same 

### DIFF
--- a/app/components/Root.jsx
+++ b/app/components/Root.jsx
@@ -128,8 +128,17 @@ export class Root extends Component {
     let canClickPrev = !!prevIndex || prevIndex === 0;
     let canClickNext = !!nextIndex;
 
-    let prevClick = () => dispatch(showAnnotation(prevIndex));
-    let nextClick = () => dispatch(showAnnotation(nextIndex));
+    let prevClick = () => {
+      let url = window.parent.location.pathname + "?annotation=" + prevIndex.toString();
+      window.parent.history.pushState(null, null, url);
+      dispatch(showAnnotation(prevIndex));
+    }
+    let nextClick = () => {
+      let url = window.parent.location.pathname + "?annotation=" + nextIndex.toString();
+      window.parent.history.pushState(null, null, url);
+      dispatch(showAnnotation(nextIndex));
+    }
+
     let update = (index, data) => dispatch(updateAnnotation(index, data));
     let remove = (index) => dispatch(deleteAnnotation(index));
     let show = (index) => dispatch(showAnnotation(index));
@@ -283,8 +292,7 @@ export class Root extends Component {
     }
 
     //to handle browser history events
-    window.history.pushState({}, '', '/');
-    window.onpopstate = this.handleBrowserBack.bind(this);
+    window.parent.onpopstate = this.handleBrowserBack.bind(this);
   }
 
   componentDidUpdate(prevProps) {
@@ -308,15 +316,16 @@ export class Root extends Component {
   }
 
   handleBrowserBack() {
-    let { dispatch } = this.props;
+    let { dispatch, currentIndex } = this.props;
     if(this.props.currentIndex) {
-      //Reduce current index if current index is not 0
+      //Reduce current index if current index is not 0  
+      let url = window.parent.location.pathname + "?annotation=" + (currentIndex - 1).toString();
+      window.parent.parent.history.pushState({}, '', url);
       dispatch(showAnnotation(this.props.currentIndex?(this.props.currentIndex - 1):0));
-      window.history.pushState({}, '', '/');
     }
     else{
       //redirect to back page if current index is not 0
-      window.history.back()
+      window.parent.history.go(-1)
     }
   }
 

--- a/app/components/Root.jsx
+++ b/app/components/Root.jsx
@@ -42,10 +42,32 @@ import keys from 'lodash/keys';
 import filter from 'lodash/filter';
 import { legacyEdgesConverter } from '../helpers';
 
+const annotationUrlIndex = {
+  '#The_Fed_has_a_role_to_play_in_Puerto_Rico': 0,
+  '#But_Fed_action_would_result_in_losses_for_hedge_funds': 1,
+  '#Hedge_fund_managers_active': 2,
+  '#Four_former_Fed_governors_have_ties_to_hedge_funds': 3,
+  '#Hedge_fund_managers_active_in_PR_also_sit_on_a_little-known_Fed_advisory_committee': 4,
+  '#Notably_the_CEO_of_Popular_sits_on_the_New_York_Fed_board': 5
+}
+
+const annotationIndexUrl = [
+  '?#The_Fed_has_a_role_to_play_in_Puerto_Rico',
+  '?#But_Fed_action_would_result_in_losses_for_hedge_funds',
+  '?#Hedge_fund_managers_active',
+  '?#Four_former_Fed_governors_have_ties_to_hedge_funds',
+  '?#Hedge_fund_managers_active_in_PR_also_sit_on_a_little-known_Fed_advisory_committee',
+  '?#Notably_the_CEO_of_Popular_sits_on_the_New_York_Fed_board'
+]
+
 export class Root extends Component {
   constructor(props) {
     super(props);
     this.state = { shiftKey: false };
+    //Set state depending upon the url search
+    if(annotationUrlIndex[window.parent.location.hash]){
+      this.props.dispatch(showAnnotation(parseInt(annotationUrlIndex[window.parent.location.hash])))
+    }
   }
 
   render() {
@@ -129,12 +151,12 @@ export class Root extends Component {
     let canClickNext = !!nextIndex;
 
     let prevClick = () => {
-      let url = window.parent.location.pathname + "?annotation=" + prevIndex.toString();
+      let url = window.parent.location.pathname + annotationIndexUrl[prevIndex];
       window.parent.history.pushState(null, null, url);
       dispatch(showAnnotation(prevIndex));
     }
     let nextClick = () => {
-      let url = window.parent.location.pathname + "?annotation=" + nextIndex.toString();
+      let url = window.parent.location.pathname + annotationIndexUrl[nextIndex];
       window.parent.history.pushState(null, null, url);
       dispatch(showAnnotation(nextIndex));
     }
@@ -319,8 +341,8 @@ export class Root extends Component {
     let { dispatch, currentIndex } = this.props;
     if(this.props.currentIndex) {
       //Reduce current index if current index is not 0  
-      let url = window.parent.location.pathname + "?annotation=" + (currentIndex - 1).toString();
-      window.parent.parent.history.pushState({}, '', url);
+      let url = window.parent.location.pathname + annotationIndexUrl[currentIndex - 1];
+      window.parent.history.pushState({}, '', url);
       dispatch(showAnnotation(this.props.currentIndex?(this.props.currentIndex - 1):0));
     }
     else{

--- a/app/components/Root.jsx
+++ b/app/components/Root.jsx
@@ -309,10 +309,9 @@ export class Root extends Component {
 
     //match url to state
     if(window.parent.history.state === ""){//when user refreshes that page
-      let annotationString = document.getElementById('oligrapherAnnotationListItems').getElementsByTagName("LI")
       let urlIndex = 0
-      for(let i=0; i<annotationString.length; i++){
-        if('?' + annotationString[i].innerHTML.replace(/\ /g, '_') === window.parent.location.search){
+      for(let i=0; i<this.props.annotations.length; i++){
+        if('?' + this.props.annotations[i].header.replace(/\ /g, '_') === window.parent.location.search){
           urlIndex = i
         }
       }
@@ -320,7 +319,7 @@ export class Root extends Component {
       dispatch(showAnnotation(urlIndex))
     }
     else{//when user navigates to some other tab
-      let url = window.parent.location.pathname + '?' + document.getElementById('oligrapherAnnotationListItems').getElementsByTagName("LI")[currentIndex].innerHTML.replace(/\ /g, '_');
+      let url = window.parent.location.pathname + '?' + this.props.annotations[currentIndex].header.replace(/\ /g, '_');
       window.parent.history.replaceState('updated', '', url);
     }
   }

--- a/app/components/Root.jsx
+++ b/app/components/Root.jsx
@@ -266,6 +266,8 @@ export class Root extends Component {
     );
   }
 
+
+
   componentDidMount() {
     let { dispatch, data, settings, isEditor } = this.props;
 
@@ -279,6 +281,10 @@ export class Root extends Component {
     if (settings) {
       dispatch(setSettings(settings));
     }
+
+    //to handle browser history events
+    window.history.pushState({}, '', '/');
+    window.onpopstate = this.handleBrowserBack.bind(this);
   }
 
   componentDidUpdate(prevProps) {
@@ -298,6 +304,19 @@ export class Root extends Component {
       if (this.props.onUpdate) {      
           this.props.onUpdate(this.props.graph);
       }
+    }
+  }
+
+  handleBrowserBack() {
+    let { dispatch } = this.props;
+    if(this.props.currentIndex) {
+      //Reduce current index if current index is not 0
+      dispatch(showAnnotation(this.props.currentIndex?(this.props.currentIndex - 1):0));
+      window.history.pushState({}, '', '/');
+    }
+    else{
+      //redirect to back page if current index is not 0
+      window.history.back()
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "oligrapher2",
-  "version": "0.3.1",
+  "version": "0.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
* The URLs change according to content/annotation title when navigating between tabs and are bookmarkable. 
* Therefore, the URLs are not hard coded, but are generated on page load. 
* Fresh page loads (where the URL has the new #annotation_title_one bookmark) will go straight there. 
* Partial matches work too -  #annotation_title_o will do the same as  #annotation_title_one if unique.


