### PR TITLE
Make it possible to change image center.

### DIFF
--- a/app/components/NodeImage.jsx
+++ b/app/components/NodeImage.jsx
@@ -7,15 +7,24 @@ const IMAGE_SCALE = 3
 const IMAGE_OPAICTY = 1
 
 export function NodeImage({ node }) {
-  const { id, x, y, image, scale } = node
+  const { id, x, y, image, scale, ix, iy } = node
   const radius = NODE_RADIUS * scale
   const imageWidth = IMAGE_SCALE * radius
   const clipPathId = `image-clip-${id}`
+  var image_x = (x - (imageWidth/2))
+  var image_y = (y - (imageWidth/2))
 
   if (!node.image) {
     return null
   }
 
+  if (typeof ix !== 'undefined' && ix) {
+      var image_x = (image_x + ix)
+  }
+
+  if (typeof iy !== 'undefined' && iy) {
+      var image_y = (image_y + iy)
+  }
   return (
     <>
       <clipPath id={clipPathId}>
@@ -29,8 +38,8 @@ export function NodeImage({ node }) {
       <image
         href={image}
         className="node-image draggable-node-handle"
-        x={x - (imageWidth/2)}
-        y={y - (imageWidth/2)}
+        x={image_x}
+        y={image_y}
         height={imageWidth}
         width={imageWidth}
         opacity={IMAGE_OPAICTY}


### PR DESCRIPTION
This pull request is intended as the starting point for enabling users to adjust how images are displayed in nodes. This change allows adjustment the "center point" of an image, in order to reposition it within the circle. You you might want to do that to show someone's whole head while pulling their image directly from remote sources, like Wikipedia. This saves having to crop them. By using an offset, nodes can still be moved around freely without losing their image's new center.

More specifically, the change introduces `ix`, and `iy` to the `display` object in the node attributes. Both are optional (so nothing breaks). If supplied, they are added to the calculated `x` and `y` values for the image (respectively).

To test it out, once you've pulled this change into your dev instance, you can use [this simple graph set](https://github.com/public-accountability/oligrapher/files/4848463/imagerecenter.js.txt) in the `blank.html` example file. I've only change the `iy` value in those, but `ix` works too.

I am happy to refine the pull request, but figured I would offer it up "as-is" first, to see if there interest in the idea. My largest concern is that I used `var` rather than `const`, which may lead to issues with performance. While I think they should be fairly modest, I certainly haven't done any benchmarking. 

